### PR TITLE
Add BestItemMode argument for best item based on Platinum, Ducats, or the default calculation

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -17,10 +17,10 @@ use notify::{watcher, RecursiveMode, Watcher};
 use xcap::Window;
 
 use wfinfo::{
+    config::BestItemMode,
     database::Database,
     ocr::{normalize_string, reward_image_to_reward_names, OCR},
     utils::fetch_prices_and_items,
-    config::BestItemMode,
 };
 
 fn run_detection(capturer: &Window, db: &Database, arguments: &Arguments) {
@@ -37,13 +37,12 @@ fn run_detection(capturer: &Window, db: &Database, arguments: &Arguments) {
     let best = items
         .iter()
         .map(|item| {
-            item.map(|item| {
-                match arguments.best_item_mode {
-                    BestItemMode::Default => item.platinum
-                        .max(item.ducats as f32 / 10.0 + item.platinum / 100.0),
-                    BestItemMode::Platinum => item.platinum,
-                    BestItemMode::Ducats => item.ducats as f32 / 10.0,
-                }
+            item.map(|item| match arguments.best_item_mode {
+                BestItemMode::Default => item
+                    .platinum
+                    .max(item.ducats as f32 / 10.0 + item.platinum / 100.0),
+                BestItemMode::Platinum => item.platinum,
+                BestItemMode::Ducats => item.ducats as f32 / 10.0,
             })
             .unwrap_or(0.0)
         })
@@ -180,7 +179,10 @@ struct Arguments {
 fn main() -> Result<(), Box<dyn Error>> {
     let arguments = Arguments::parse();
     let default_log_path = PathBuf::from_str(&std::env::var("HOME").unwrap()).unwrap().join(PathBuf::from_str(".local/share/Steam/steamapps/compatdata/230410/pfx/drive_c/users/steamuser/AppData/Local/Warframe/EE.log")?);
-    let log_path = arguments.game_log_file_path.as_ref().unwrap_or(&default_log_path);
+    let log_path = arguments
+        .game_log_file_path
+        .as_ref()
+        .unwrap_or(&default_log_path);
     let window_name = arguments.window_name.clone();
     let env = Env::default()
         .filter_or("WFINFO_LOG", "info")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,9 @@
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub enum BestItemMode {
+    #[default]
+    Default,
+    Platinum,
+    Ducats,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod config;
 pub mod database;
 pub mod ocr;
 pub mod statistics;
@@ -5,4 +6,3 @@ pub mod testing;
 pub mod theme;
 pub mod utils;
 pub mod wfinfo_data;
-pub mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,4 @@ pub mod testing;
 pub mod theme;
 pub mod utils;
 pub mod wfinfo_data;
+pub mod config;


### PR DESCRIPTION
Add BestItemMode enum and update run_detection to support item selection mode

- Introduced a new `BestItemMode` enum in `config.rs` to allow users to specify how the best item is determined (Default, Platinum, Ducats).
- Updated the `run_detection` function in `main.rs` to accept an `Arguments` struct, enabling the selection of the best item mode based on user input.
- Modified item evaluation logic to accommodate the new best item mode options.
- Updated the `Arguments` struct to include a new command-line argument for best item mode with a default value.