### PR TITLE
Update xcap to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.144", features = ["serde_derive"] }
 serde-aux = "3.1.0"
 serde_json = "1.0.85"
 tesseract = "0.12.0"
-xcap = "0.0.4"
+xcap = "0.7.1"
 log = "0.4.22"
 env_logger = "0.11.5"
 reqwest = { version = "0.12.7", features = ["blocking"] }

--- a/src/bin/image.rs
+++ b/src/bin/image.rs
@@ -1,6 +1,6 @@
 use std::{fs::write, path::PathBuf};
 
-use image::io::Reader;
+use xcap::image::ImageReader;
 use indexmap::IndexMap;
 use wfinfo::{
     database::Database,
@@ -13,7 +13,7 @@ fn main() {
 
     for argument in std::env::args().skip(1) {
         let filepath = PathBuf::from(argument);
-        let image = Reader::open(&filepath).unwrap().decode().unwrap();
+        let image = ImageReader::open(&filepath).unwrap().decode().unwrap();
 
         let detections = reward_image_to_reward_names(image.clone(), None);
         println!("{:#?}", detections);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -11,7 +11,7 @@ use std::{path::PathBuf, sync::mpsc};
 use clap::Parser;
 use env_logger::{Builder, Env};
 use global_hotkey::{hotkey::HotKey, GlobalHotKeyEvent, GlobalHotKeyManager, HotKeyState};
-use image::DynamicImage;
+use xcap::image::DynamicImage;
 use log::{debug, error, info, warn};
 use notify::{watcher, RecursiveMode, Watcher};
 use xcap::Window;
@@ -139,7 +139,7 @@ fn hotkey_watcher(hotkey: HotKey, event_sender: mpsc::Sender<()>) {
 #[allow(dead_code)]
 fn benchmark() -> Result<(), Box<dyn Error>> {
     for _ in 0..10 {
-        let image = image::open("input3.png").unwrap();
+        let image = xcap::image::open("input3.png").unwrap();
         println!("Converted");
         let text = reward_image_to_reward_names(image, None);
         println!("got names");
@@ -181,7 +181,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     let windows = Window::all()?;
-    let Some(warframe_window) = windows.iter().find(|x| x.title() == window_name) else {
+    let Some(warframe_window) = windows.iter().find(|x| x.title().unwrap_or("".to_owned()) == window_name) else {
         return Err("Warframe window not found".into());
     };
 
@@ -215,7 +215,7 @@ mod test {
     use std::collections::BTreeMap;
     use std::fs::read_to_string;
 
-    use image::io::Reader;
+    use xcap::image::io::Reader;
     use indexmap::IndexMap;
     use rayon::prelude::*;
     use tesseract::Tesseract;

--- a/src/bin/theme_tune.rs
+++ b/src/bin/theme_tune.rs
@@ -11,7 +11,7 @@ use eframe::{
     epaint::ColorImage,
 };
 use egui_extras::RetainedImage;
-use image::{io::Reader, DynamicImage, Rgb};
+use xcap::image::{ImageReader, DynamicImage, Rgb};
 use palette::{FromColor, Hsl, Srgb};
 use wfinfo::{
     database::Database,
@@ -44,7 +44,7 @@ impl Default for MyApp {
     fn default() -> Self {
         let original_images = std::env::args()
             .skip(1)
-            .map(|name| Reader::open(name).unwrap().decode().unwrap())
+            .map(|name| ImageReader::open(name).unwrap().decode().unwrap())
             .collect();
         let settings = HslRange {
             saturation: 0.50..1.0,

--- a/src/ocr.rs
+++ b/src/ocr.rs
@@ -4,7 +4,7 @@ use std::f32::consts::PI;
 use std::{collections::HashMap, sync::Mutex};
 use tesseract::Tesseract;
 
-use image::{DynamicImage, GenericImageView, Pixel, Rgb};
+use xcap::image::{DynamicImage, GenericImageView, Pixel, Rgb};
 use log::debug;
 
 use crate::theme::Theme;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use image::Rgb;
+use xcap::image::Rgb;
 use ordered_float::OrderedFloat;
 use palette::{FromColor, Hsl, RgbHue, Srgb};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
This updates xcap from a positively ancient version to the current release, fixing a number of issues I experienced on my system with window recognition. It also uses the re-exported xcap definitions of image:: types.