### PR TITLE
Require 200 status code before overwriting saved API response

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,7 +18,7 @@ fn download_and_save(url: &str, filename: &str) -> Result<PathBuf, anyhow::Error
     }
 
     let res = reqwest::blocking::get(url)?;
-    if res.status() == 200 {
+    if res.status() == StatusCode::OK {
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
+use reqwest::StatusCode;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
-use reqwest::StatusCode;
 
 pub fn fetch_prices_and_items() -> Result<(PathBuf, PathBuf), anyhow::Error> {
     let prices = download_and_save("https://api.warframestat.us/wfinfo/prices/", "prices.json")?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,12 +18,15 @@ fn download_and_save(url: &str, filename: &str) -> Result<PathBuf, anyhow::Error
     }
 
     let res = reqwest::blocking::get(url)?;
-    let mut file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .create(true)
-        .open(&path)?;
-    file.write_all(res.text()?.as_bytes())?;
+    if res.status() == 200 {
+
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(&path)?;
+        file.write_all(res.text()?.as_bytes())?;
+    }
 
     Ok(path)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,6 @@ fn download_and_save(url: &str, filename: &str) -> Result<PathBuf, anyhow::Error
 
     let res = reqwest::blocking::get(url)?;
     if res.status() == 200 {
-
         let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::PathBuf;
+use reqwest::StatusCode;
 
 pub fn fetch_prices_and_items() -> Result<(PathBuf, PathBuf), anyhow::Error> {
     let prices = download_and_save("https://api.warframestat.us/wfinfo/prices/", "prices.json")?;


### PR DESCRIPTION
I ran into an issue where the API was down and the download_and_save function overwrote my locally saved copy of the API responses and caused wfinfo to be unable to run. This PR changes that behavior to only overwrite the files if the API response has a status code of 200, so the program will still run with whatever the most recent successfully downloaded API responses are.

First time users are still out of luck with this implementation if the API is down, but it should help most users. 